### PR TITLE
ParseIntPipeの削除

### DIFF
--- a/src/trips/trips.controller.ts
+++ b/src/trips/trips.controller.ts
@@ -5,7 +5,6 @@ import {
   Get,
   HttpCode,
   Param,
-  ParseIntPipe,
   Patch,
   Post,
   Request,
@@ -44,7 +43,7 @@ export class TripsController {
 
   @Patch(':id')
   update(
-    @Param('id', ParseIntPipe) id: string,
+    @Param('id') id: string,
     @Body() dto: UpdateTripDto,
     @Request() req: { user: { userId: string } },
   ) {
@@ -54,7 +53,7 @@ export class TripsController {
   @Delete(':id')
   @HttpCode(204)
   remove(
-    @Param('id', ParseIntPipe) id: string,
+    @Param('id') id: string,
     @Request() req: { user: { userId: string } },
   ) {
     return this.tripsService.remove(id, req.user.userId);


### PR DESCRIPTION
ParseIntPipeは受け取ったパラメータを整数に変換しようとするパイプですが、tripのIDは UUID です。UUIDは整数に変換できないため、NestJS がハンドラに到達する前にエラーを投げ、500 レスポンスが返っていました。 ParseIntPipeの表記を削除しました。