### PR TITLE
ParseIntPipeの削除・旅行IDの属性変更

### DIFF
--- a/src/expenses/expense.entity.ts
+++ b/src/expenses/expense.entity.ts
@@ -27,6 +27,6 @@ export class Expense {
   @JoinColumn({ name: 'trip_id' })
   trip!: Trip;
 
-  @Column({ name: 'trip_id' })
-  tripId!: number;
+  @Column({ name: 'trip_id', type: 'uuid' })
+  tripId!: string;
 }

--- a/src/expenses/expenses.controller.ts
+++ b/src/expenses/expenses.controller.ts
@@ -1,4 +1,14 @@
-import { Body, Controller, Delete, HttpCode, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  HttpCode,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { ExpensesService } from './expenses.service';
 import { CreateExpenseDto } from './dto/create-expense.dto';
 import { UpdateExpenseDto } from './dto/update-expense.dto';
@@ -10,24 +20,18 @@ export class ExpensesController {
   constructor(private readonly expensesService: ExpensesService) {}
 
   @Post('trips/:tripId/expenses')
-  create(
-    @Param('tripId', ParseIntPipe) tripId: number,
-    @Body() dto: CreateExpenseDto,
-  ) {
+  create(@Param('tripId') tripId: string, @Body() dto: CreateExpenseDto) {
     return this.expensesService.create(tripId, dto);
   }
 
   @Patch('expenses/:id')
-  update(
-    @Param('id', ParseIntPipe) id: number,
-    @Body() dto: UpdateExpenseDto,
-  ) {
+  update(@Param('id') id: number, @Body() dto: UpdateExpenseDto) {
     return this.expensesService.update(id, dto);
   }
 
   @Delete('expenses/:id')
   @HttpCode(204)
-  remove(@Param('id', ParseIntPipe) id: number) {
+  remove(@Param('id') id: number) {
     return this.expensesService.remove(id);
   }
 }

--- a/src/expenses/expenses.service.ts
+++ b/src/expenses/expenses.service.ts
@@ -12,7 +12,7 @@ export class ExpensesService {
     private readonly expensesRepository: Repository<Expense>,
   ) {}
 
-  create(tripId: number, dto: CreateExpenseDto): Promise<Expense> {
+  create(tripId: string, dto: CreateExpenseDto): Promise<Expense> {
     const expense = this.expensesRepository.create({ ...dto, tripId });
     return this.expensesRepository.save(expense);
   }

--- a/src/spots/spot.entity.ts
+++ b/src/spots/spot.entity.ts
@@ -37,6 +37,6 @@ export class Spot {
   @JoinColumn({ name: 'trip_id' })
   trip!: Trip;
 
-  @Column({ name: 'trip_id' })
-  tripId!: number;
+  @Column({ name: 'trip_id', type: 'uuid' })
+  tripId!: string;
 }

--- a/src/spots/spots.controller.ts
+++ b/src/spots/spots.controller.ts
@@ -11,7 +11,7 @@ export class SpotsController {
 
   @Post('trips/:tripId/spots')
   create(
-    @Param('tripId', ParseIntPipe) tripId: number,
+    @Param('tripId') tripId: string,
     @Body() dto: CreateSpotDto,
   ) {
     return this.spotsService.create(tripId, dto);

--- a/src/spots/spots.service.ts
+++ b/src/spots/spots.service.ts
@@ -12,7 +12,7 @@ export class SpotsService {
     private readonly spotsRepository: Repository<Spot>,
   ) {}
 
-  create(tripId: number, dto: CreateSpotDto): Promise<Spot> {
+  create(tripId: string, dto: CreateSpotDto): Promise<Spot> {
     const spot = this.spotsRepository.create({ ...dto, tripId });
     return this.spotsRepository.save(spot);
   }


### PR DESCRIPTION
- spot、expensesでのParseIntPipeの表記を削除しました。
- 旅行IDをUUIDに変更したのに合わせ、型をnumber->stringに変更しました。